### PR TITLE
Add modular tutorial Q&A agent with multiple deployment options

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,10 @@ name = "pypi"
 [packages]
 django = "==3.2"
 djangorestframework = "*"
+openai = "*"
+requests = "*"
+fastapi = "*"
+pydantic = "*"
 
 [dev-packages]
 black = "*"

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,13 @@
+"""Modular tutorial question-answering agent."""
+
+__all__ = ["answer_question", "reindex_tutorial"]
+
+
+def answer_question(*args, **kwargs):  # pragma: no cover - thin wrapper
+    from .main import answer_question as _answer
+    return _answer(*args, **kwargs)
+
+
+def reindex_tutorial(*args, **kwargs):  # pragma: no cover - thin wrapper
+    from .reindex import reindex_tutorial as _reindex
+    return _reindex(*args, **kwargs)

--- a/agent/clients.py
+++ b/agent/clients.py
@@ -1,0 +1,126 @@
+"""API client implementations for external services."""
+
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+
+import requests
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai may not be installed
+    openai = None
+
+from .config import settings
+
+
+class StrapiClient:
+    """Fetch tutorial metadata from a Strapi CMS instance."""
+
+    def __init__(self, base_url: str | None = None, token: str | None = None) -> None:
+        self.base_url = (base_url or settings.strapi_url).rstrip("/")
+        self.token = token or settings.strapi_token
+
+    def get_tutorial(self, tutorial_id: int) -> dict:
+        url = f"{self.base_url}/api/tutorials/{tutorial_id}?populate=*"
+        headers: dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json().get("data", {})
+        attributes = data.get("attributes", {})
+        tags = [t.get("name", "") for t in attributes.get("tags", {}).get("data", [])]
+        return {
+            "title": attributes.get("title", ""),
+            "tags": tags,
+            "description": attributes.get("description", ""),
+        }
+
+
+class MuxClient:
+    """Retrieve video transcripts from Mux."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token or settings.mux_token
+
+    def get_transcript(self, video_id: str) -> str:
+        url = f"https://stream.mux.com/{video_id}/text.vtt"
+        headers: dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.text
+
+
+class SupabaseClient:
+    """Minimal Supabase client using RESTful endpoints."""
+
+    def __init__(self, url: str | None = None, key: str | None = None) -> None:
+        self.url = url or settings.supabase_url
+        self.key = key or settings.supabase_key
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "apikey": self.key or "",
+            "Authorization": f"Bearer {self.key}" if self.key else "",
+            "Content-Type": "application/json",
+        }
+
+    def get_comments(self, tutorial_id: int) -> List[str]:
+        if not self.url or not self.key:
+            return []
+        params = {"tutorial_id": f"eq.{tutorial_id}", "select": "content"}
+        response = requests.get(f"{self.url}/rest/v1/comments", params=params, headers=self._headers(), timeout=10)
+        response.raise_for_status()
+        return [c.get("content", "") for c in response.json()]
+
+    def log_interaction(self, payload: dict) -> None:
+        if not self.url or not self.key:
+            return
+        requests.post(
+            f"{self.url}/rest/v1/interactions",
+            headers=self._headers(),
+            data=json.dumps(payload),
+            timeout=10,
+        ).raise_for_status()
+
+    def upsert_index(self, tutorial_id: int, metadata: dict, transcript: str) -> None:
+        if not self.url or not self.key:
+            return
+        payload = {
+            "tutorial_id": tutorial_id,
+            "title": metadata.get("title", ""),
+            "tags": metadata.get("tags", []),
+            "description": metadata.get("description", ""),
+            "transcript": transcript,
+        }
+        requests.post(
+            f"{self.url}/rest/v1/tutorial_index",
+            headers=self._headers(),
+            data=json.dumps(payload),
+            timeout=10,
+        ).raise_for_status()
+
+
+class OpenAIClient:
+    """Wrapper around the OpenAI Chat Completions API."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-4o") -> None:
+        self.api_key = api_key or settings.openai_api_key
+        self.model = model
+
+    def ask(self, system_prompt: str, question: str) -> str:
+        if openai is None:
+            raise RuntimeError("openai package is not installed")
+        openai.api_key = self.api_key
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": question},
+            ],
+        )
+        return response.choices[0].message["content"]

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,19 @@
+"""Configuration dataclass for API credentials."""
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Settings:
+    """Application settings loaded from environment variables."""
+
+    strapi_url: str = os.getenv("STRAPI_URL", "")
+    strapi_token: str | None = os.getenv("STRAPI_TOKEN")
+    mux_token: str | None = os.getenv("MUX_TOKEN")
+    openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
+    supabase_url: str | None = os.getenv("SUPABASE_URL")
+    supabase_key: str | None = os.getenv("SUPABASE_KEY")
+
+
+settings = Settings()

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,0 +1,49 @@
+"""Core agent logic for building context and answering questions."""
+
+from __future__ import annotations
+
+from .clients import MuxClient, OpenAIClient, StrapiClient, SupabaseClient
+
+strapi_client = StrapiClient()
+mux_client = MuxClient()
+supabase_client = SupabaseClient()
+openai_client = OpenAIClient()
+
+
+def build_context(tutorial_id: int | None, video_id: str | None) -> str:
+    """Collect metadata, transcripts and comments into a context string."""
+    parts: list[str] = []
+    metadata: dict = {}
+    comments: list[str] = []
+    transcript = ""
+
+    if tutorial_id is not None:
+        metadata = strapi_client.get_tutorial(tutorial_id)
+        comments = supabase_client.get_comments(tutorial_id)
+    if video_id:
+        transcript = mux_client.get_transcript(video_id)
+
+    if metadata:
+        parts.append(f"Title: {metadata.get('title', '')}")
+        if metadata.get("tags"):
+            parts.append("Tags: " + ", ".join(metadata["tags"]))
+        if metadata.get("description"):
+            parts.append("Description: " + metadata["description"])
+    if transcript:
+        parts.append("Transcript:\n" + transcript)
+    if comments:
+        parts.append("Comments:\n" + "\n".join(comments))
+    return "\n".join(parts)
+
+
+def answer_question(question: str, tutorial_id: int | None = None, video_id: str | None = None, log: bool = True) -> str:
+    """Return an OpenAI-generated answer for the given question."""
+    system_prompt = build_context(tutorial_id, video_id)
+    answer = openai_client.ask(system_prompt, question)
+    if log and tutorial_id is not None:
+        supabase_client.log_interaction({
+            "tutorial_id": tutorial_id,
+            "question": question,
+            "answer": answer,
+        })
+    return answer

--- a/agent/reindex.py
+++ b/agent/reindex.py
@@ -1,0 +1,23 @@
+"""Utilities for reindexing tutorials when content changes."""
+
+from __future__ import annotations
+
+from .clients import MuxClient, StrapiClient, SupabaseClient
+
+strapi_client = StrapiClient()
+mux_client = MuxClient()
+supabase_client = SupabaseClient()
+
+
+def reindex_tutorial(tutorial_id: int, video_id: str | None = None) -> dict:
+    """Refresh metadata and transcript for a tutorial in Supabase index."""
+    metadata = strapi_client.get_tutorial(tutorial_id)
+    if video_id is None:
+        video_id = metadata.get("video_id")
+    transcript = mux_client.get_transcript(video_id) if video_id else ""
+    supabase_client.upsert_index(tutorial_id, metadata, transcript)
+    return {
+        "tutorial_id": tutorial_id,
+        "metadata": metadata,
+        "transcript": transcript,
+    }

--- a/api/fastapi_app.py
+++ b/api/fastapi_app.py
@@ -1,0 +1,26 @@
+"""FastAPI endpoint exposing the tutorial agent."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from agent import answer_question
+
+app = FastAPI()
+
+
+class Query(BaseModel):
+    question: str
+    tutorial_id: int | None = None
+    video_id: str | None = None
+
+
+@app.post("/ask")
+def ask(query: Query) -> dict:
+    answer = answer_question(
+        question=query.question,
+        tutorial_id=query.tutorial_id,
+        video_id=query.video_id,
+    )
+    return {"answer": answer}

--- a/api/n8n_handler.py
+++ b/api/n8n_handler.py
@@ -1,0 +1,17 @@
+"""HTTP handler compatible with n8n's HTTP Request node."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from agent import answer_question
+
+
+def handler(event: Dict[str, Any], context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    body = json.loads(event.get("body", "{}"))
+    question = body.get("question", "")
+    tutorial_id = body.get("tutorial_id")
+    video_id = body.get("video_id")
+    answer = answer_question(question, tutorial_id, video_id)
+    return {"statusCode": 200, "body": json.dumps({"answer": answer})}

--- a/api/vercel_handler.py
+++ b/api/vercel_handler.py
@@ -1,0 +1,20 @@
+"""Vercel serverless function entrypoint."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent import answer_question
+
+
+def handler(request: Any) -> Any:
+    if hasattr(request, "json"):
+        body = request.json()
+    else:
+        body = json.loads(getattr(request, "body", "{}"))
+    question = body.get("question", "")
+    tutorial_id = body.get("tutorial_id")
+    video_id = body.get("video_id")
+    answer = answer_question(question, tutorial_id, video_id)
+    return {"statusCode": 200, "body": json.dumps({"answer": answer})}


### PR DESCRIPTION
## Summary
- implement modular agent that fetches tutorial metadata, transcripts, and comments, calls OpenAI, and logs to Supabase
- provide reindexing utility for updating cached tutorial data
- expose agent via FastAPI, n8n-compatible handler, and Vercel serverless function
- declare required dependencies

## Testing
- `pipenv run python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68907ae732d8832fba5d5089858dcb89